### PR TITLE
Add fields to `generic_port_instance_struct` to accomdate changes in reactor-c

### DIFF
--- a/include/pythontarget.h
+++ b/include/pythontarget.h
@@ -111,6 +111,10 @@ typedef struct {
     PyObject* value;
     bool is_present;
     int num_destinations;
+    lf_token_t* token;
+    int length;
+    void (*destructor) (void* value);
+    void* (*copy_constructor) (void* value);
     FEDERATED_CAPSULE_EXTENSION
 } generic_port_instance_struct;
 


### PR DESCRIPTION
fields added:
- `token`
- `length`
- `destructor`
- `copy_constructor`