### PR TITLE
Attempt to fix Windows problem with Python build

### DIFF
--- a/include/pythontarget.h
+++ b/include/pythontarget.h
@@ -59,6 +59,10 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define PATH_MAX MAX_PATH
 #endif
 #endif
+// For some reason, on Windows, this still ends up undefined.
+#ifndef PATH_MAX
+#define PATH_MAX 1024
+#endif
 
 // MODULE_NAME is expected to be defined in the main file of the generated code
 #ifndef MODULE_NAME

--- a/include/pythontarget.h
+++ b/include/pythontarget.h
@@ -53,7 +53,8 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "python_port.h"
 #include "python_action.h"
 
-#ifdef _MSC_VER
+// #ifdef _MSC_VER
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
 #ifndef PATH_MAX
 #define PATH_MAX MAX_PATH
 #endif


### PR DESCRIPTION
Windows and Posix disagree (of course) on how to define maximum path length. A build failure unrelated to anything else I am doing started appearing because the following fails to define `PATH_MAX`:
```
#ifdef _MSC_VER
#ifndef PATH_MAX
#define PATH_MAX MAX_PATH
#endif
#endif
```
This PR replaces this with:
```
#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
#ifndef PATH_MAX
#define PATH_MAX MAX_PATH
#endif
#endif
```
Hopefully this will be more robust.