### PR TITLE
Struct refactoring for actions and ports

### DIFF
--- a/include/python_action.h
+++ b/include/python_action.h
@@ -59,8 +59,9 @@ typedef struct {
     lf_token_t* token;
     size_t length;
     bool is_present;
+    lf_action_internal_t _base;
+    self_base_t* parent;
     bool has_value;
-    trigger_t* trigger;
     PyObject* value;
     FEDERATED_GENERIC_EXTENSION
 } generic_action_instance_struct;

--- a/include/python_port.h
+++ b/include/python_port.h
@@ -61,9 +61,7 @@ typedef struct {
     lf_token_t* token;                       // token_template_t
     size_t length;                           // token_template_t
     bool is_present;                         // lf_port_base_t
-    lf_sparse_io_record_t* sparse_record;    // lf_port_base_t
-    int destination_channel;                 // lf_port_base_t
-    int num_destinations;                    // lf_port_base_t
+    lf_port_internal_t _base;                // lf_port_internal_t
     PyObject* value;
     FEDERATED_GENERIC_EXTENSION
 } generic_port_instance_struct;


### PR DESCRIPTION
This PR refactors the structs associated with ports and actions to make a clearer distinction between fields that are user-visible and those that are only used internally by the runtime. It also adds a parent pointer to the struct for actions. There is a corresponding PR in both lingua-franca and reactor-c.